### PR TITLE
Fix for bogus From field when name contains non-ASCII characters (#6)

### DIFF
--- a/index.py
+++ b/index.py
@@ -12,6 +12,7 @@ import ipaddress
 import smtplib
 from email.mime.nonmultipart import MIMENonMultipart
 import email.charset
+import email.header
 import pystache
 import textwrap
 
@@ -156,14 +157,15 @@ def serveRequest(config, postbody):
             too = repo.get("email", {}).get("to").split(",")
             headers = {}
             frum_name = ""
-            readable_frum = frum
+            readable_frum = email.header.Header(charset='utf8', header_name='From')
             if config.get("GH_OAUTH_TOKEN", False):
                 headers['Authorization']="token %s" % (config["GH_OAUTH_TOKEN"])
                 frum_name = requests.get(payload['sender']['url'],
                                      headers=headers
                                      ).json().get('name', payload['sender']['login'])
-                readable_frum = u"%s via GitHub <%s>" % (frum_name, frum)
+                readable_frum.append('%s via GitHub' % (frum_name))
 
+            readable_frum.append('<%s>' % (frum), charset='us-ascii')
             msg['From'] = readable_frum
             msg['To'] = ",".join(too)
             msg['Subject'] = subject


### PR DESCRIPTION
The main issue is that the whole string was encoded, whereas only the user's
name should be. The email address (only composed of ASCII characters) and
the enclosing `<` and `>` must remain intact in particular, as in:

  `From: =?utf-8?q?Fran=C3=83ois_via_GitHub?= <foo@example.com>`

This update uses "email.header.Header" to encode header parts sequentially, see:

  https://docs.python.org/2/library/email.header.html

The code would benefit from being tested as I do not have the right setting
here so merely tested it in a separate Python file :)

Also, the Python doc uses an example with the `Subject` header. Could a similar bug affect that header as well?