### PR TITLE
Display labels when available.

### DIFF
--- a/index.py
+++ b/index.py
@@ -160,6 +160,7 @@ def extractDigestInfo(events, eventFilter=None):
             issue["commentscount"] = 0
             issue["commentors"] = set()
             issue["ispr"] = comment["payload"]["issue"].has_key("pull_request")
+            issue["labels"] = comment["payload"]["issue"]["labels"]
             commentedissues[number] = issue
         commentedissues[number]["commentscount"] += 1
         commentedissues[number]["commentors"].add(comment["actor"]["display_login"])

--- a/templates/generic/digest
+++ b/templates/generic/digest
@@ -20,20 +20,20 @@
 {{#newissues.count}}  {{.}} issues created:
 {{#newissues.list}}
   - {{{payload.issue.title}}} (by {{actor.display_login}})
-    {{{payload.issue.html_url}}}
+    {{{payload.issue.html_url}}} {{#payload.issue.labels}}[{{name}}] {{/payload.issue.labels}}
 {{/newissues.list}}
 
 {{/newissues.count}}
 {{#commentedissues.count}}  {{.}} issues received {{issuecommentscount}} new comments:
 {{#commentedissues.list}}
   - #{{number}} {{{title}}} ({{commentscount}} by {{#commentors}}{{name}}{{^last}}, {{/last}}{{/commentors}})
-    {{{url}}}
+    {{{url}}} {{#labels}}[{{name}}] {{/labels}}
 {{/commentedissues.list}}
 
 {{/commentedissues.count}}
 {{#closedissues.count}}  {{.}} issues closed:
 {{#closedissues.list}}
-  - {{{payload.issue.title}}} {{{payload.issue.html_url}}}
+  - {{{payload.issue.title}}} {{{payload.issue.html_url}}} {{#payload.issue.labels}}[{{name}}] {{/payload.issue.labels}}
 {{/closedissues.list}}
 
 {{/closedissues.count}}
@@ -46,21 +46,21 @@
 {{#newpr.count}}  {{.}} pull requests submitted:
 {{#newpr.list}}
   - {{{payload.pull_request.title}}} (by {{actor.display_login}})
-    {{{payload.pull_request.html_url}}}
+    {{{payload.pull_request.html_url}}} {{#payload.pull_request.labels}}[{{name}}] {{/payload.pull_request.labels}}
 {{/newpr.list}}
 
 {{/newpr.count}}
 {{#commentedpr.count}}  {{.}} pull requests received {{prcommentscount}} new comments:
 {{#commentedpr.list}}
   - #{{number}} {{{title}}} ({{commentscount}} by {{#commentors}}{{name}}{{^last}}, {{/last}}{{/commentors}})
-    {{{url}}}
+    {{{url}}} {{#labels}}[{{name}}] {{/labels}}
 {{/commentedpr.list}}
 
 {{/commentedpr.count}}
 {{#mergedpr.count}}  {{.}} pull requests merged:
 {{#mergedpr.list}}
   - {{{payload.pull_request.title}}}
-    {{{payload.pull_request.html_url}}}
+    {{{payload.pull_request.html_url}}} {{#payload.pull_request.labels}}[{{name}}] {{/payload.pull_request.labels}}
 {{/mergedpr.list}}
 
 {{/mergedpr.count}}

--- a/templates/generic/digest.html
+++ b/templates/generic/digest.html
@@ -9,9 +9,20 @@ h2 { margin-top: 3em; color: #A52A2A; font-style: italic; font-weight: normal; }
 h3 { margin-bottom:0; margin-top: 2em; font-size: 1.2em; }
 h1+h2 { margin-top: 1em; }
 a { color: #bb6219; text-decoration: none; }
-li { margin-bottom: .2em; }
+li { margin-bottom: .35em; }
 .repos { margin-bottom: 0; margin-top:0; line-height: 1.2; }
 .new { color: red; }
+.label { display: inline;
+	padding: .2em .6em .3em;
+	font-size: 75%;
+	font-weight: 700;
+	line-height: 1;
+	color: #fff;
+	text-align: center;
+	white-space: nowrap;
+	vertical-align: baseline;
+	border-radius: .25em;
+}
 </style>
 </head>
 
@@ -23,7 +34,7 @@ li { margin-bottom: .2em; }
 </ul>
 {{/errors.count}}
 
-{{#filtered}}<p>Events {{#filteredlabels}}with label {{#labels}}"{{name}}"{{^last}}, {{/last}}{{/labels}}{{#filteredantilabels}} and {{/filteredantilabels}}{{/filteredlabels}}{{#filteredantilabels}}without label {{#antilabels}}"{{name}}"{{^last}}, {{/last}}{{/antilabels}}{{/filteredantilabels}}</p>
+{{#filtered}}<p>Events {{#filteredlabels}}with label {{#labels}}<span class="label">{{name}}</span>{{^last}}, {{/last}}{{/labels}}{{#filteredantilabels}} and {{/filteredantilabels}}{{/filteredlabels}}{{#filteredantilabels}}without label {{#antilabels}}"{{name}}"{{^last}}, {{/last}}{{/antilabels}}{{/filteredantilabels}}</p>
 {{/filtered}}
 
 {{#summary}}<h2>Repositories</h2>
@@ -39,19 +50,19 @@ li { margin-bottom: .2em; }
 <h3>{{name}} (+{{newissues.count}}/-{{closedissues.count}}/💬{{issuecommentscount}})</h3>
 {{#newissues.count}}  <p class="new">{{.}} issues created:</p>
   <ul>{{#newissues.list}}
-  <li>#{{payload.issue.number}} <a href="{{payload.issue.html_url}}">{{payload.issue.title}}</a> (by {{actor.display_login}})</li>
+  <li>#{{payload.issue.number}} <a href="{{payload.issue.html_url}}">{{payload.issue.title}}</a> (by {{actor.display_login}}) {{#payload.issue.labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/payload.issue.labels}}</li>
   {{/newissues.list}}</ul>
 {{/newissues.count}}
 
 {{#commentedissues.count}}  <p>{{.}} issues received {{issuecommentscount}} new comments:</p>
   <ul>{{#commentedissues.list}}
-  <li>#{{number}} <a href="{{url}}">{{title}}</a> ({{commentscount}} by {{#commentors}}{{name}}{{^last}}, {{/last}}{{/commentors}})</li>
+  <li>#{{number}} <a href="{{url}}">{{title}}</a> ({{commentscount}} by {{#commentors}}{{name}}{{^last}}, {{/last}}{{/commentors}}) {{#labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/labels}}</li>
   {{/commentedissues.list}}</ul>
 {{/commentedissues.count}}
 
 {{#closedissues.count}}  <p>{{.}} issues closed:</p>
   <ul>{{#closedissues.list}}
-  <li>#{{payload.issue.number}} <a href="{{payload.issue.html_url}}">{{payload.issue.title}}</a></li>
+  <li>#{{payload.issue.number}} <a href="{{payload.issue.html_url}}">{{payload.issue.title}}</a> {{#payload.issue.labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/payload.issue.labels}}</li>
   {{/closedissues.list}}</ul>
 {{/closedissues.count}}
 
@@ -62,19 +73,19 @@ li { margin-bottom: .2em; }
 <h3>{{name}} (+{{newpr.count}}/-{{mergedpr.count}}/💬{{prcommentscount}})</h3>
 {{#newpr.count}}  <p class="new">{{.}} pull requests submitted:</p>
   <ul>{{#newpr.list}}
-  <li>#{{payload.pull_request.number}} <a href="{{payload.pull_request.html_url}}">{{payload.pull_request.title}}</a> (by {{actor.display_login}})</li>
+  <li>#{{payload.pull_request.number}} <a href="{{payload.pull_request.html_url}}">{{payload.pull_request.title}}</a> (by {{actor.display_login}}) {{#payload.pull_request.labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/payload.pull_request.labels}}</li>
   {{/newpr.list}}</ul>
 {{/newpr.count}}
 
 {{#commentedpr.count}}  <p>{{.}} pull requests received {{prcommentscount}} new comments:</p>
   <ul>{{#commentedpr.list}}
-  <li>#{{number}} <a href="{{url}}">{{title}}</a> ({{commentscount}} by {{#commentors}}{{name}}{{^last}}, {{/last}}{{/commentors}})</li>
+  <li>#{{number}} <a href="{{url}}">{{title}}</a> ({{commentscount}} by {{#commentors}}{{name}}{{^last}}, {{/last}}{{/commentors}}) {{#labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/labels}}</li>
   {{/commentedpr.list}}</ul>
 {{/commentedpr.count}}
 
 {{#mergedpr.count}}  <p>{{.}} pull requests merged:</p>
   <ul>{{#mergedpr.list}}
-  <li>#{{payload.pull_request.number}} <a href="{{payload.pull_request.html_url}}">{{payload.pull_request.title}}</a></li>
+  <li>#{{payload.pull_request.number}} <a href="{{payload.pull_request.html_url}}">{{payload.pull_request.title}}</a> {{#payload.pull_request.labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/payload.pull_request.labels}}</li>
   {{/mergedpr.list}}</ul>
 {{/mergedpr.count}}
 

--- a/templates/generic/digest.html
+++ b/templates/generic/digest.html
@@ -50,19 +50,19 @@ li { margin-bottom: .35em; }
 <h3>{{name}} (+{{newissues.count}}/-{{closedissues.count}}/💬{{issuecommentscount}})</h3>
 {{#newissues.count}}  <p class="new">{{.}} issues created:</p>
   <ul>{{#newissues.list}}
-  <li>#{{payload.issue.number}} <a href="{{payload.issue.html_url}}">{{payload.issue.title}}</a> (by {{actor.display_login}}) {{#payload.issue.labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/payload.issue.labels}}</li>
+  <li>#{{payload.issue.number}} <a href="{{payload.issue.html_url}}">{{payload.issue.title}}</a> (by {{actor.display_login}}) {{#payload.issue.labels}}<span class="label" style="background-color: #{{color}}; color: #{{text_color}}">{{name}}</span> {{/payload.issue.labels}}</li>
   {{/newissues.list}}</ul>
 {{/newissues.count}}
 
 {{#commentedissues.count}}  <p>{{.}} issues received {{issuecommentscount}} new comments:</p>
   <ul>{{#commentedissues.list}}
-  <li>#{{number}} <a href="{{url}}">{{title}}</a> ({{commentscount}} by {{#commentors}}{{name}}{{^last}}, {{/last}}{{/commentors}}) {{#labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/labels}}</li>
+  <li>#{{number}} <a href="{{url}}">{{title}}</a> ({{commentscount}} by {{#commentors}}{{name}}{{^last}}, {{/last}}{{/commentors}}) {{#labels}}<span class="label" style="background-color: #{{color}}; color: #{{text_color}}">{{name}}</span> {{/labels}}</li>
   {{/commentedissues.list}}</ul>
 {{/commentedissues.count}}
 
 {{#closedissues.count}}  <p>{{.}} issues closed:</p>
   <ul>{{#closedissues.list}}
-  <li>#{{payload.issue.number}} <a href="{{payload.issue.html_url}}">{{payload.issue.title}}</a> {{#payload.issue.labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/payload.issue.labels}}</li>
+  <li>#{{payload.issue.number}} <a href="{{payload.issue.html_url}}">{{payload.issue.title}}</a> {{#payload.issue.labels}}<span class="label" style="background-color: #{{color}}; color: #{{text_color}}">{{name}}</span> {{/payload.issue.labels}}</li>
   {{/closedissues.list}}</ul>
 {{/closedissues.count}}
 
@@ -73,19 +73,19 @@ li { margin-bottom: .35em; }
 <h3>{{name}} (+{{newpr.count}}/-{{mergedpr.count}}/💬{{prcommentscount}})</h3>
 {{#newpr.count}}  <p class="new">{{.}} pull requests submitted:</p>
   <ul>{{#newpr.list}}
-  <li>#{{payload.pull_request.number}} <a href="{{payload.pull_request.html_url}}">{{payload.pull_request.title}}</a> (by {{actor.display_login}}) {{#payload.pull_request.labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/payload.pull_request.labels}}</li>
+  <li>#{{payload.pull_request.number}} <a href="{{payload.pull_request.html_url}}">{{payload.pull_request.title}}</a> (by {{actor.display_login}}) {{#payload.pull_request.labels}}<span class="label" style="background-color: #{{color}}; color: #{{text_color}}">{{name}}</span> {{/payload.pull_request.labels}}</li>
   {{/newpr.list}}</ul>
 {{/newpr.count}}
 
 {{#commentedpr.count}}  <p>{{.}} pull requests received {{prcommentscount}} new comments:</p>
   <ul>{{#commentedpr.list}}
-  <li>#{{number}} <a href="{{url}}">{{title}}</a> ({{commentscount}} by {{#commentors}}{{name}}{{^last}}, {{/last}}{{/commentors}}) {{#labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/labels}}</li>
+  <li>#{{number}} <a href="{{url}}">{{title}}</a> ({{commentscount}} by {{#commentors}}{{name}}{{^last}}, {{/last}}{{/commentors}}) {{#labels}}<span class="label" style="background-color: #{{color}}; color: #{{text_color}}">{{name}}</span> {{/labels}}</li>
   {{/commentedpr.list}}</ul>
 {{/commentedpr.count}}
 
 {{#mergedpr.count}}  <p>{{.}} pull requests merged:</p>
   <ul>{{#mergedpr.list}}
-  <li>#{{payload.pull_request.number}} <a href="{{payload.pull_request.html_url}}">{{payload.pull_request.title}}</a> {{#payload.pull_request.labels}}<span class="label" style="background-color: #{{color}}">{{name}}</span> {{/payload.pull_request.labels}}</li>
+  <li>#{{payload.pull_request.number}} <a href="{{payload.pull_request.html_url}}">{{payload.pull_request.title}}</a> {{#payload.pull_request.labels}}<span class="label" style="background-color: #{{color}}; color: #{{text_color}}">{{name}}</span> {{/payload.pull_request.labels}}</li>
   {{/mergedpr.list}}</ul>
 {{/mergedpr.count}}
 

--- a/tests/digest-weekly-filtered.msg
+++ b/tests/digest-weekly-filtered.msg
@@ -16,11 +16,11 @@ Issues
 
   1 issues received 5 new comments:
   - #888 Section 6.2:  Issue 3 - buffered data at transport close (5 by jesup, feross, taylor-b, alvestrand)
-    https://github.com/w3c/webrtc-pc/issues/888
+    https://github.com/w3c/webrtc-pc/issues/888 [PR exists] 
 
 
   1 issues closed:
-  - Section 6.2:  Issue 3 - buffered data at transport close https://github.com/w3c/webrtc-pc/issues/888
+  - Section 6.2:  Issue 3 - buffered data at transport close https://github.com/w3c/webrtc-pc/issues/888 [PR exists] 
 
 
 

--- a/tests/digest-weekly-filtered.msg.html
+++ b/tests/digest-weekly-filtered.msg.html
@@ -46,13 +46,13 @@ li { margin-bottom: .35em; }
 
   <p>1 issues received 5 new comments:</p>
   <ul>
-  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> (5 by jesup, feross, taylor-b, alvestrand) <span class="label" style="background-color: #009800">PR exists</span> </li>
+  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> (5 by jesup, feross, taylor-b, alvestrand) <span class="label" style="background-color: #009800; color: #ffffff">PR exists</span> </li>
   </ul>
 
 
   <p>1 issues closed:</p>
   <ul>
-  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> <span class="label" style="background-color: #009800">PR exists</span> </li>
+  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> <span class="label" style="background-color: #009800; color: #ffffff">PR exists</span> </li>
   </ul>
 
 

--- a/tests/digest-weekly-filtered.msg.html
+++ b/tests/digest-weekly-filtered.msg.html
@@ -13,9 +13,20 @@ h2 { margin-top: 3em; color: #A52A2A; font-style: italic; font-weight: normal; }
 h3 { margin-bottom:0; margin-top: 2em; font-size: 1.2em; }
 h1+h2 { margin-top: 1em; }
 a { color: #bb6219; text-decoration: none; }
-li { margin-bottom: .2em; }
+li { margin-bottom: .35em; }
 .repos { margin-bottom: 0; margin-top:0; line-height: 1.2; }
 .new { color: red; }
+.label { display: inline;
+	padding: .2em .6em .3em;
+	font-size: 75%;
+	font-weight: 700;
+	line-height: 1;
+	color: #fff;
+	text-align: center;
+	white-space: nowrap;
+	vertical-align: baseline;
+	border-radius: .25em;
+}
 </style>
 </head>
 
@@ -24,7 +35,7 @@ li { margin-bottom: .2em; }
 <h1>Wednesday November 16, 2016</h1>
 
 
-<p>Events with label "PR exists" and without label "List discussion needed"</p>
+<p>Events with label <span class="label">PR exists</span> and without label "List discussion needed"</p>
 
 
 <h2>Issues</h2>
@@ -35,13 +46,13 @@ li { margin-bottom: .2em; }
 
   <p>1 issues received 5 new comments:</p>
   <ul>
-  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> (5 by jesup, feross, taylor-b, alvestrand)</li>
+  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> (5 by jesup, feross, taylor-b, alvestrand) <span class="label" style="background-color: #009800">PR exists</span> </li>
   </ul>
 
 
   <p>1 issues closed:</p>
   <ul>
-  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a></li>
+  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> <span class="label" style="background-color: #009800">PR exists</span> </li>
   </ul>
 
 

--- a/tests/digest-weekly.msg
+++ b/tests/digest-weekly.msg
@@ -13,33 +13,33 @@ Issues
 * w3c/webrtc-pc (+5/-2/💬12)
   5 issues created:
   - replaceTrack(null): Allowed? (by aboba)
-    https://github.com/w3c/webrtc-pc/issues/947
+    https://github.com/w3c/webrtc-pc/issues/947 
   - sender.setParameters():  Changing simulcast parameters? (by aboba)
-    https://github.com/w3c/webrtc-pc/issues/945
+    https://github.com/w3c/webrtc-pc/issues/945 
   - Effect of sender.replaceTrack(null) (by aboba)
-    https://github.com/w3c/webrtc-pc/issues/943
+    https://github.com/w3c/webrtc-pc/issues/943 
   - Meta: auto-publish changes to the spec (by foolip)
-    https://github.com/w3c/webrtc-pc/issues/942
+    https://github.com/w3c/webrtc-pc/issues/942 
   - STUN/TURN Auto Discovery handling (by misi)
-    https://github.com/w3c/webrtc-pc/issues/941
+    https://github.com/w3c/webrtc-pc/issues/941 
 
 
   5 issues received 12 new comments:
   - #888 Section 6.2:  Issue 3 - buffered data at transport close (5 by jesup, feross, taylor-b, alvestrand)
-    https://github.com/w3c/webrtc-pc/issues/888
+    https://github.com/w3c/webrtc-pc/issues/888 [PR exists] 
   - #714 STUN/TURN OAuth token auth parameter passing (3 by juberti, misi)
-    https://github.com/w3c/webrtc-pc/issues/714
+    https://github.com/w3c/webrtc-pc/issues/714 [External feedback] [July interim topic] [List discussion needed] [November interim topic] [PR exists] 
   - #803 Rules for negotiation-needed flag need to be updated for transceivers. (2 by taylor-b, aboba)
-    https://github.com/w3c/webrtc-pc/issues/803
+    https://github.com/w3c/webrtc-pc/issues/803 [November interim topic] 
   - #942 Meta: auto-publish changes to the spec (1 by henbos)
-    https://github.com/w3c/webrtc-pc/issues/942
+    https://github.com/w3c/webrtc-pc/issues/942 
   - #927 What happens when setDirection() is called (1 by taylor-b)
-    https://github.com/w3c/webrtc-pc/issues/927
+    https://github.com/w3c/webrtc-pc/issues/927 [November interim topic] 
 
 
   2 issues closed:
-  - Rules for negotiation-needed flag need to be updated for transceivers. https://github.com/w3c/webrtc-pc/issues/803
-  - Section 6.2:  Issue 3 - buffered data at transport close https://github.com/w3c/webrtc-pc/issues/888
+  - Rules for negotiation-needed flag need to be updated for transceivers. https://github.com/w3c/webrtc-pc/issues/803 [November interim topic] 
+  - Section 6.2:  Issue 3 - buffered data at transport close https://github.com/w3c/webrtc-pc/issues/888 [PR exists] 
 
 
 
@@ -51,43 +51,43 @@ Pull requests
 * w3c/webrtc-pc (+8/-1/💬10)
   8 pull requests submitted:
   - Revert "Respec now uses yarn instead of npm" (by vivienlacourba)
-    https://github.com/w3c/webrtc-pc/pull/948
+    https://github.com/w3c/webrtc-pc/pull/948 
   - Splitting transceiver direction into "direction" and "currentDirection". (by taylor-b)
-    https://github.com/w3c/webrtc-pc/pull/946
+    https://github.com/w3c/webrtc-pc/pull/946 
   - Effect of setting sender.track to null (by aboba)
-    https://github.com/w3c/webrtc-pc/pull/944
+    https://github.com/w3c/webrtc-pc/pull/944 
   - Use of "stopped" in insertDTMF and replaceTrack (by aboba)
-    https://github.com/w3c/webrtc-pc/pull/940
+    https://github.com/w3c/webrtc-pc/pull/940 
   - Removed "stopped" from removeTrack (by aboba)
-    https://github.com/w3c/webrtc-pc/pull/939
+    https://github.com/w3c/webrtc-pc/pull/939 
   - What happens when setDirection() is called (by aboba)
-    https://github.com/w3c/webrtc-pc/pull/938
+    https://github.com/w3c/webrtc-pc/pull/938 
   - What happens when transceiver.stop() is called (by aboba)
-    https://github.com/w3c/webrtc-pc/pull/937
+    https://github.com/w3c/webrtc-pc/pull/937 
   - Remove Issue 1: Current and Pending SDP (by aboba)
-    https://github.com/w3c/webrtc-pc/pull/936
+    https://github.com/w3c/webrtc-pc/pull/936 
 
 
   7 pull requests received 10 new comments:
   - #944 Effect of setting sender.track to null (4 by pthatcherg, aboba)
-    https://github.com/w3c/webrtc-pc/pull/944
+    https://github.com/w3c/webrtc-pc/pull/944 
   - #929 Have RTCSessionDescription's sdp member default to "" (1 by jan-ivar)
-    https://github.com/w3c/webrtc-pc/pull/929
+    https://github.com/w3c/webrtc-pc/pull/929 
   - #939 Removed "stopped" from removeTrack (1 by aboba)
-    https://github.com/w3c/webrtc-pc/pull/939
+    https://github.com/w3c/webrtc-pc/pull/939 
   - #940 Use of "stopped" in insertDTMF and replaceTrack (1 by aboba)
-    https://github.com/w3c/webrtc-pc/pull/940
+    https://github.com/w3c/webrtc-pc/pull/940 
   - #920 Revise text dealing with with the ICE Agent/User Agent interactions. (1 by aboba)
-    https://github.com/w3c/webrtc-pc/pull/920
+    https://github.com/w3c/webrtc-pc/pull/920 [November interim topic] 
   - #946 Splitting transceiver direction into "direction" and "currentDirection". (1 by aboba)
-    https://github.com/w3c/webrtc-pc/pull/946
+    https://github.com/w3c/webrtc-pc/pull/946 
   - #919 Removing incorrect statement related to IP leaking issue. (1 by vivienlacourba)
-    https://github.com/w3c/webrtc-pc/pull/919
+    https://github.com/w3c/webrtc-pc/pull/919 
 
 
   1 pull requests merged:
   - Respec now uses yarn instead of npm
-    https://github.com/w3c/webrtc-pc/pull/935
+    https://github.com/w3c/webrtc-pc/pull/935 
 
 
 

--- a/tests/digest-weekly.msg.html
+++ b/tests/digest-weekly.msg.html
@@ -62,23 +62,23 @@ Errors while compiling the digest:
 
   <p>5 issues received 12 new comments:</p>
   <ul>
-  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> (5 by jesup, feross, taylor-b, alvestrand) <span class="label" style="background-color: #009800">PR exists</span> </li>
+  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> (5 by jesup, feross, taylor-b, alvestrand) <span class="label" style="background-color: #009800; color: #ffffff">PR exists</span> </li>
   
-  <li>#714 <a href="https://github.com/w3c/webrtc-pc/issues/714">STUN/TURN OAuth token auth parameter passing</a> (3 by juberti, misi) <span class="label" style="background-color: #f9d0c4">External feedback</span> <span class="label" style="background-color: #bfdadc">July interim topic</span> <span class="label" style="background-color: #fbca04">List discussion needed</span> <span class="label" style="background-color: #d93f0b">November interim topic</span> <span class="label" style="background-color: #009800">PR exists</span> </li>
+  <li>#714 <a href="https://github.com/w3c/webrtc-pc/issues/714">STUN/TURN OAuth token auth parameter passing</a> (3 by juberti, misi) <span class="label" style="background-color: #f9d0c4; color: #000000">External feedback</span> <span class="label" style="background-color: #bfdadc; color: #000000">July interim topic</span> <span class="label" style="background-color: #fbca04; color: #000000">List discussion needed</span> <span class="label" style="background-color: #d93f0b; color: #ffffff">November interim topic</span> <span class="label" style="background-color: #009800; color: #ffffff">PR exists</span> </li>
   
-  <li>#803 <a href="https://github.com/w3c/webrtc-pc/issues/803">Rules for negotiation-needed flag need to be updated for transceivers.</a> (2 by taylor-b, aboba) <span class="label" style="background-color: #d93f0b">November interim topic</span> </li>
+  <li>#803 <a href="https://github.com/w3c/webrtc-pc/issues/803">Rules for negotiation-needed flag need to be updated for transceivers.</a> (2 by taylor-b, aboba) <span class="label" style="background-color: #d93f0b; color: #ffffff">November interim topic</span> </li>
   
   <li>#942 <a href="https://github.com/w3c/webrtc-pc/issues/942">Meta: auto-publish changes to the spec</a> (1 by henbos) </li>
   
-  <li>#927 <a href="https://github.com/w3c/webrtc-pc/issues/927">What happens when setDirection() is called</a> (1 by taylor-b) <span class="label" style="background-color: #d93f0b">November interim topic</span> </li>
+  <li>#927 <a href="https://github.com/w3c/webrtc-pc/issues/927">What happens when setDirection() is called</a> (1 by taylor-b) <span class="label" style="background-color: #d93f0b; color: #ffffff">November interim topic</span> </li>
   </ul>
 
 
   <p>2 issues closed:</p>
   <ul>
-  <li>#803 <a href="https://github.com/w3c/webrtc-pc/issues/803">Rules for negotiation-needed flag need to be updated for transceivers.</a> <span class="label" style="background-color: #d93f0b">November interim topic</span> </li>
+  <li>#803 <a href="https://github.com/w3c/webrtc-pc/issues/803">Rules for negotiation-needed flag need to be updated for transceivers.</a> <span class="label" style="background-color: #d93f0b; color: #ffffff">November interim topic</span> </li>
   
-  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> <span class="label" style="background-color: #009800">PR exists</span> </li>
+  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> <span class="label" style="background-color: #009800; color: #ffffff">PR exists</span> </li>
   </ul>
 
 
@@ -118,7 +118,7 @@ Errors while compiling the digest:
   
   <li>#940 <a href="https://github.com/w3c/webrtc-pc/pull/940">Use of &quot;stopped&quot; in insertDTMF and replaceTrack</a> (1 by aboba) </li>
   
-  <li>#920 <a href="https://github.com/w3c/webrtc-pc/pull/920">Revise text dealing with with the ICE Agent/User Agent interactions.</a> (1 by aboba) <span class="label" style="background-color: #d93f0b">November interim topic</span> </li>
+  <li>#920 <a href="https://github.com/w3c/webrtc-pc/pull/920">Revise text dealing with with the ICE Agent/User Agent interactions.</a> (1 by aboba) <span class="label" style="background-color: #d93f0b; color: #ffffff">November interim topic</span> </li>
   
   <li>#946 <a href="https://github.com/w3c/webrtc-pc/pull/946">Splitting transceiver direction into &quot;direction&quot; and &quot;currentDirection&quot;.</a> (1 by aboba) </li>
   

--- a/tests/digest-weekly.msg.html
+++ b/tests/digest-weekly.msg.html
@@ -13,9 +13,20 @@ h2 { margin-top: 3em; color: #A52A2A; font-style: italic; font-weight: normal; }
 h3 { margin-bottom:0; margin-top: 2em; font-size: 1.2em; }
 h1+h2 { margin-top: 1em; }
 a { color: #bb6219; text-decoration: none; }
-li { margin-bottom: .2em; }
+li { margin-bottom: .35em; }
 .repos { margin-bottom: 0; margin-top:0; line-height: 1.2; }
 .new { color: red; }
+.label { display: inline;
+	padding: .2em .6em .3em;
+	font-size: 75%;
+	font-weight: 700;
+	line-height: 1;
+	color: #fff;
+	text-align: center;
+	white-space: nowrap;
+	vertical-align: baseline;
+	border-radius: .25em;
+}
 </style>
 </head>
 
@@ -37,37 +48,37 @@ Errors while compiling the digest:
 <h3>w3c/webrtc-pc (+5/-2/💬12)</h3>
   <p class="new">5 issues created:</p>
   <ul>
-  <li>#947 <a href="https://github.com/w3c/webrtc-pc/issues/947">replaceTrack(null): Allowed?</a> (by aboba)</li>
+  <li>#947 <a href="https://github.com/w3c/webrtc-pc/issues/947">replaceTrack(null): Allowed?</a> (by aboba) </li>
   
-  <li>#945 <a href="https://github.com/w3c/webrtc-pc/issues/945">sender.setParameters():  Changing simulcast parameters?</a> (by aboba)</li>
+  <li>#945 <a href="https://github.com/w3c/webrtc-pc/issues/945">sender.setParameters():  Changing simulcast parameters?</a> (by aboba) </li>
   
-  <li>#943 <a href="https://github.com/w3c/webrtc-pc/issues/943">Effect of sender.replaceTrack(null)</a> (by aboba)</li>
+  <li>#943 <a href="https://github.com/w3c/webrtc-pc/issues/943">Effect of sender.replaceTrack(null)</a> (by aboba) </li>
   
-  <li>#942 <a href="https://github.com/w3c/webrtc-pc/issues/942">Meta: auto-publish changes to the spec</a> (by foolip)</li>
+  <li>#942 <a href="https://github.com/w3c/webrtc-pc/issues/942">Meta: auto-publish changes to the spec</a> (by foolip) </li>
   
-  <li>#941 <a href="https://github.com/w3c/webrtc-pc/issues/941">STUN/TURN Auto Discovery handling</a> (by misi)</li>
+  <li>#941 <a href="https://github.com/w3c/webrtc-pc/issues/941">STUN/TURN Auto Discovery handling</a> (by misi) </li>
   </ul>
 
 
   <p>5 issues received 12 new comments:</p>
   <ul>
-  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> (5 by jesup, feross, taylor-b, alvestrand)</li>
+  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> (5 by jesup, feross, taylor-b, alvestrand) <span class="label" style="background-color: #009800">PR exists</span> </li>
   
-  <li>#714 <a href="https://github.com/w3c/webrtc-pc/issues/714">STUN/TURN OAuth token auth parameter passing</a> (3 by juberti, misi)</li>
+  <li>#714 <a href="https://github.com/w3c/webrtc-pc/issues/714">STUN/TURN OAuth token auth parameter passing</a> (3 by juberti, misi) <span class="label" style="background-color: #f9d0c4">External feedback</span> <span class="label" style="background-color: #bfdadc">July interim topic</span> <span class="label" style="background-color: #fbca04">List discussion needed</span> <span class="label" style="background-color: #d93f0b">November interim topic</span> <span class="label" style="background-color: #009800">PR exists</span> </li>
   
-  <li>#803 <a href="https://github.com/w3c/webrtc-pc/issues/803">Rules for negotiation-needed flag need to be updated for transceivers.</a> (2 by taylor-b, aboba)</li>
+  <li>#803 <a href="https://github.com/w3c/webrtc-pc/issues/803">Rules for negotiation-needed flag need to be updated for transceivers.</a> (2 by taylor-b, aboba) <span class="label" style="background-color: #d93f0b">November interim topic</span> </li>
   
-  <li>#942 <a href="https://github.com/w3c/webrtc-pc/issues/942">Meta: auto-publish changes to the spec</a> (1 by henbos)</li>
+  <li>#942 <a href="https://github.com/w3c/webrtc-pc/issues/942">Meta: auto-publish changes to the spec</a> (1 by henbos) </li>
   
-  <li>#927 <a href="https://github.com/w3c/webrtc-pc/issues/927">What happens when setDirection() is called</a> (1 by taylor-b)</li>
+  <li>#927 <a href="https://github.com/w3c/webrtc-pc/issues/927">What happens when setDirection() is called</a> (1 by taylor-b) <span class="label" style="background-color: #d93f0b">November interim topic</span> </li>
   </ul>
 
 
   <p>2 issues closed:</p>
   <ul>
-  <li>#803 <a href="https://github.com/w3c/webrtc-pc/issues/803">Rules for negotiation-needed flag need to be updated for transceivers.</a></li>
+  <li>#803 <a href="https://github.com/w3c/webrtc-pc/issues/803">Rules for negotiation-needed flag need to be updated for transceivers.</a> <span class="label" style="background-color: #d93f0b">November interim topic</span> </li>
   
-  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a></li>
+  <li>#888 <a href="https://github.com/w3c/webrtc-pc/issues/888">Section 6.2:  Issue 3 - buffered data at transport close</a> <span class="label" style="background-color: #009800">PR exists</span> </li>
   </ul>
 
 
@@ -79,45 +90,45 @@ Errors while compiling the digest:
 <h3>w3c/webrtc-pc (+8/-1/💬10)</h3>
   <p class="new">8 pull requests submitted:</p>
   <ul>
-  <li>#948 <a href="https://github.com/w3c/webrtc-pc/pull/948">Revert &quot;Respec now uses yarn instead of npm&quot;</a> (by vivienlacourba)</li>
+  <li>#948 <a href="https://github.com/w3c/webrtc-pc/pull/948">Revert &quot;Respec now uses yarn instead of npm&quot;</a> (by vivienlacourba) </li>
   
-  <li>#946 <a href="https://github.com/w3c/webrtc-pc/pull/946">Splitting transceiver direction into &quot;direction&quot; and &quot;currentDirection&quot;.</a> (by taylor-b)</li>
+  <li>#946 <a href="https://github.com/w3c/webrtc-pc/pull/946">Splitting transceiver direction into &quot;direction&quot; and &quot;currentDirection&quot;.</a> (by taylor-b) </li>
   
-  <li>#944 <a href="https://github.com/w3c/webrtc-pc/pull/944">Effect of setting sender.track to null</a> (by aboba)</li>
+  <li>#944 <a href="https://github.com/w3c/webrtc-pc/pull/944">Effect of setting sender.track to null</a> (by aboba) </li>
   
-  <li>#940 <a href="https://github.com/w3c/webrtc-pc/pull/940">Use of &quot;stopped&quot; in insertDTMF and replaceTrack</a> (by aboba)</li>
+  <li>#940 <a href="https://github.com/w3c/webrtc-pc/pull/940">Use of &quot;stopped&quot; in insertDTMF and replaceTrack</a> (by aboba) </li>
   
-  <li>#939 <a href="https://github.com/w3c/webrtc-pc/pull/939">Removed &quot;stopped&quot; from removeTrack</a> (by aboba)</li>
+  <li>#939 <a href="https://github.com/w3c/webrtc-pc/pull/939">Removed &quot;stopped&quot; from removeTrack</a> (by aboba) </li>
   
-  <li>#938 <a href="https://github.com/w3c/webrtc-pc/pull/938">What happens when setDirection() is called</a> (by aboba)</li>
+  <li>#938 <a href="https://github.com/w3c/webrtc-pc/pull/938">What happens when setDirection() is called</a> (by aboba) </li>
   
-  <li>#937 <a href="https://github.com/w3c/webrtc-pc/pull/937">What happens when transceiver.stop() is called</a> (by aboba)</li>
+  <li>#937 <a href="https://github.com/w3c/webrtc-pc/pull/937">What happens when transceiver.stop() is called</a> (by aboba) </li>
   
-  <li>#936 <a href="https://github.com/w3c/webrtc-pc/pull/936">Remove Issue 1: Current and Pending SDP</a> (by aboba)</li>
+  <li>#936 <a href="https://github.com/w3c/webrtc-pc/pull/936">Remove Issue 1: Current and Pending SDP</a> (by aboba) </li>
   </ul>
 
 
   <p>7 pull requests received 10 new comments:</p>
   <ul>
-  <li>#944 <a href="https://github.com/w3c/webrtc-pc/pull/944">Effect of setting sender.track to null</a> (4 by pthatcherg, aboba)</li>
+  <li>#944 <a href="https://github.com/w3c/webrtc-pc/pull/944">Effect of setting sender.track to null</a> (4 by pthatcherg, aboba) </li>
   
-  <li>#929 <a href="https://github.com/w3c/webrtc-pc/pull/929">Have RTCSessionDescription's sdp member default to &quot;&quot;</a> (1 by jan-ivar)</li>
+  <li>#929 <a href="https://github.com/w3c/webrtc-pc/pull/929">Have RTCSessionDescription's sdp member default to &quot;&quot;</a> (1 by jan-ivar) </li>
   
-  <li>#939 <a href="https://github.com/w3c/webrtc-pc/pull/939">Removed &quot;stopped&quot; from removeTrack</a> (1 by aboba)</li>
+  <li>#939 <a href="https://github.com/w3c/webrtc-pc/pull/939">Removed &quot;stopped&quot; from removeTrack</a> (1 by aboba) </li>
   
-  <li>#940 <a href="https://github.com/w3c/webrtc-pc/pull/940">Use of &quot;stopped&quot; in insertDTMF and replaceTrack</a> (1 by aboba)</li>
+  <li>#940 <a href="https://github.com/w3c/webrtc-pc/pull/940">Use of &quot;stopped&quot; in insertDTMF and replaceTrack</a> (1 by aboba) </li>
   
-  <li>#920 <a href="https://github.com/w3c/webrtc-pc/pull/920">Revise text dealing with with the ICE Agent/User Agent interactions.</a> (1 by aboba)</li>
+  <li>#920 <a href="https://github.com/w3c/webrtc-pc/pull/920">Revise text dealing with with the ICE Agent/User Agent interactions.</a> (1 by aboba) <span class="label" style="background-color: #d93f0b">November interim topic</span> </li>
   
-  <li>#946 <a href="https://github.com/w3c/webrtc-pc/pull/946">Splitting transceiver direction into &quot;direction&quot; and &quot;currentDirection&quot;.</a> (1 by aboba)</li>
+  <li>#946 <a href="https://github.com/w3c/webrtc-pc/pull/946">Splitting transceiver direction into &quot;direction&quot; and &quot;currentDirection&quot;.</a> (1 by aboba) </li>
   
-  <li>#919 <a href="https://github.com/w3c/webrtc-pc/pull/919">Removing incorrect statement related to IP leaking issue.</a> (1 by vivienlacourba)</li>
+  <li>#919 <a href="https://github.com/w3c/webrtc-pc/pull/919">Removing incorrect statement related to IP leaking issue.</a> (1 by vivienlacourba) </li>
   </ul>
 
 
   <p>1 pull requests merged:</p>
   <ul>
-  <li>#935 <a href="https://github.com/w3c/webrtc-pc/pull/935">Respec now uses yarn instead of npm</a></li>
+  <li>#935 <a href="https://github.com/w3c/webrtc-pc/pull/935">Respec now uses yarn instead of npm</a> </li>
   </ul>
 
 


### PR DESCRIPTION
Displays issue and PR labels when they're available (sometimes they're not in the event stream).

Possible improvements:

* [ ] Fetch most recent labels for each issue/PR (although this would add latency and traffic)
* [ ] Put it behind a flag?
* [x] Conditionally flip the text on the label between black and white based upon its background lightness/darkness

Any you'd like to see before merging?