### PR TITLE
Digest template: Don't espace topic in email subject

### DIFF
--- a/templates/generic/digest
+++ b/templates/generic/digest
@@ -1,4 +1,4 @@
-{{period}} github digest ({{#topic}}{{.}}{{/topic}}{{^topic}}{{#repos}}{{shortname}}{{^last}}, {{/last}}{{/repos}}{{/topic}})
+{{period}} github digest ({{#topic}}{{{.}}}{{/topic}}{{^topic}}{{#repos}}{{shortname}}{{^last}}, {{/last}}{{/repos}}{{/topic}})
 
 {{#errors.count}}Errors while compiling the digest:
 {{#errors.list}} - {{error}}{{/errors.list}}{{/errors.count}}


### PR DESCRIPTION
Mustache HTML-escapes variables by default:
https://mustache.github.io/mustache.5.html#Variables

Character escaping now disabled for the subject of digest emails to prevent broken subjects in digest emails such as:
https://lists.w3.org/Archives/Public/public-web-and-tv/2018Jun/0000.html

Note: I do not exactly know what is or is not allowed in text/plain messages, but I suppose escaping is problematic in the body of the message as well. There seems to remain a few double mustaches in the digest template, which should probably be replaced by triple mustaches as well. Other templates seem fine.