### PR TITLE
Add issue number to email subjects

### DIFF
--- a/templates/generic/issue_comment.created
+++ b/templates/generic/issue_comment.created
@@ -1,4 +1,4 @@
-Re: [{{{repository.name}}}] {{{issue.title}}}
+Re: [{{{repository.name}}}] {{{issue.title}}} (#{{{issue.number}}})
 {{{comment.body}}}
 
 -- 

--- a/templates/generic/issues.closed
+++ b/templates/generic/issues.closed
@@ -1,2 +1,2 @@
-Closed: [{{{repository.name}}}] {{{issue.title}}}
+Closed: [{{{repository.name}}}] {{{issue.title}}} (#{{{issue.number}}})
 {{{sender.login}}} closed this issue. See {{{issue.html_url}}}

--- a/templates/generic/issues.labeled
+++ b/templates/generic/issues.labeled
@@ -1,4 +1,4 @@
-[{{{repository.name}}}] Issue: {{{issue.title}}} marked as {{{label.name}}}
+[{{{repository.name}}}] Issue: {{{issue.title}}} (#{{{issue.number}}}) marked as {{{label.name}}}
 {{{sender.login}}} has just labeled an issue for {{{repository.html_url}}} as "{{{label.name}}}":
 
 == {{{issue.title}}} ==

--- a/templates/generic/issues.opened
+++ b/templates/generic/issues.opened
@@ -1,4 +1,4 @@
-[{{repository.name}}] {{{issue.title}}}
+[{{repository.name}}] {{{issue.title}}} (#{{{issue.number}}})
 {{{issue.user.login}}} has just created a new issue for {{{repository.html_url}}}:
 
 == {{{issue.title}}} ==

--- a/tests/issue-comment-notif.msg
+++ b/tests/issue-comment-notif.msg
@@ -3,7 +3,7 @@ Content-Transfer-Encoding: quoted-printable
 Content-Type: text/plain; charset="utf-8"; format="flowed"
 From: =?utf-8?q?Dominique_Haza=C3=ABl-Massieux_via_GitHub?= <test@localhost>
 To: dom@localhost
-Subject: Re: [github-notify-ml] Move default values to config file
+Subject: Re: [github-notify-ml] Move default values to config file (#1)
 Message-ID: <issue_comment.created-58886897-1413204426-test@localhost>
 In-Reply-To: <issues.opened-45268120-1412787119-test@localhost>
 

--- a/tests/issue-notif-log.msg
+++ b/tests/issue-notif-log.msg
@@ -3,7 +3,7 @@ Content-Transfer-Encoding: quoted-printable
 Content-Type: text/plain; charset="utf-8"; format="flowed"
 From: =?utf-8?q?Dominique_Haza=C3=ABl-Massieux_via_GitHub?= <test@localhost>
 To: log@localhost
-Subject: [github-notify-ml] Move default values to config file
+Subject: [github-notify-ml] Move default values to config file (#1)
 Message-ID: <issues.opened-45268120-1412787119-test@localhost>
 
 dontcallmedom has just created a new issue for https://github.com/dontcallmedom/github-notify-ml:

--- a/tests/issue-notif.msg
+++ b/tests/issue-notif.msg
@@ -3,7 +3,7 @@ Content-Transfer-Encoding: quoted-printable
 Content-Type: text/plain; charset="utf-8"; format="flowed"
 From: =?utf-8?q?Dominique_Haza=C3=ABl-Massieux_via_GitHub?= <test@localhost>
 To: dom@localhost
-Subject: [github-notify-ml] Move default values to config file
+Subject: [github-notify-ml] Move default values to config file (#1)
 Message-ID: <issues.opened-45268120-1412787119-test@localhost>
 
 dontcallmedom has just created a new issue for https://github.com/dontcallmedom/github-notify-ml:


### PR DESCRIPTION
GitHub notifications include the number of the issue in the subject. This is useful, e.g. to identify some emails in one's inbox. This update adds the issue number as "(#xxx)" next to the issue title.

I got this feature request from a couple of people. OK, that might include myself.

Not sure how to test this. I get 6/12 failures when I run the tests before making any change in particular.