### PR TITLE
generate compliant From: headers

### DIFF
--- a/index.py
+++ b/index.py
@@ -14,6 +14,7 @@ import smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.header import Header
+from email.utils import formataddr
 from email.generator import Generator
 import email.charset
 from cStringIO import StringIO
@@ -529,10 +530,7 @@ def sendMail(smtp, parts, from_addr, from_name, to_addr, subject, msgid=None, in
             if part['subtype'] == 'plain':
                 alt.set_param('format', 'flowed')
             msg.attach(alt)
-    readable_from = email.header.Header(charset='utf8', header_name='From')
-    readable_from.append(from_name)
-    readable_from.append('<%s>' % (from_addr), charset='us-ascii')
-    msg['From'] = readable_from
+    msg['From'] = formataddr((str(Header(from_name,'utf-8')),from_addr))
     msg['To'] = ",".join(to_addr)
     msg['Subject'] = Header(subject, 'utf-8')
     if msgid:


### PR DESCRIPTION
I believe this patch should fix #47 by using email.utils.formataddr to generate From: headers.

I tested this with a local script using various from_name strings (simple us-ascii, us-ascii containing square brackets, and utf-8 containing accented chars) and it seems to work OK, but I haven't tested this script as a whole.