### PR TITLE
Add in-memory cache of requests

### DIFF
--- a/index.py
+++ b/index.py
@@ -9,6 +9,7 @@ import json
 import re
 import subprocess
 import requests
+import requests_cache
 import ipaddress
 import smtplib
 from email.mime.text import MIMEText
@@ -22,6 +23,8 @@ from functools import reduce
 
 email.charset.add_charset("utf-8", email.charset.QP, email.charset.QP, "utf-8")
 
+# avoid re-requesting the same content in a given run
+requests_cache.install_cache(backend='memory')
 
 class InvalidConfiguration(Exception):
     pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ mock
 pystache
 ipaddress
 requests
+requests_cache
 responses
 python-dateutil

--- a/test_digest.py
+++ b/test_digest.py
@@ -102,6 +102,8 @@ class SendEmailGithubTests(unittest.TestCase):
             ],
             mock_smtp,
         )
+        self.assertEqual(len(responses.calls), 6)
+
 
     @responses.activate
     @patch("smtplib.SMTP")
@@ -109,6 +111,7 @@ class SendEmailGithubTests(unittest.TestCase):
         self.do_digest(
             "quarterly", [{"dom@localhost": "tests/summary-quarterly.msg"}], mock_smtp
         )
+        self.assertEqual(len(responses.calls), 2)
 
     def do_digest(self, period, refs, mock_smtp):
         import email
@@ -166,7 +169,6 @@ class SendEmailGithubTests(unittest.TestCase):
                 ref_body = "\n".join(ref_part.split("\n\n")[1:])
                 self.assertMultiLineEqual(sent_part["body"], ref_body)
             counter = counter + 1
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This helps when running multiple digests across a shared set of repositories