### PR TITLE
'event_timestamp' should also handle the action 'labeled'

### DIFF
--- a/index.py
+++ b/index.py
@@ -102,7 +102,7 @@ def event_timestamp(event, payload):
             ts = payload[key]["created_at"]
         elif action == "closed":
             ts = payload[key]["closed_at"]
-        elif action == "reopened" or action == "synchronize":
+        elif action == "reopened" or action == "synchronize" or action == "labeled":
             ts = payload[key]["updated_at"]
     if ts:
         return timestamp(ts)


### PR DESCRIPTION
The generated message ID relies on the event timestamp. The action 'labeled' was generating a timestamp 'None' which could lead to duplicated message IDs