### PR TITLE
Add support for allRepos tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ The set of mailing lists, repos / TR documents and events is configured in a JSO
          ]
      }
    ]
+  },
+  "email4@example.com": {
+    "digest:tuesday": [
+     {
+       "allRepos": "users/githubaccount"
+     }
+     {
+       "allRepos": "orgs/orgname"
+     }
+   ]
   }
 }
 ```

--- a/index.py
+++ b/index.py
@@ -275,6 +275,15 @@ def getRepoList(source):
     repos = []
     if ("repos" in source):
         repos = source["repos"]
+    if ("allRepos" in source):
+        try:
+            url = "https://github.com/" + source["allRepos"] + "/repos"
+            repolist = requests.get(url).json()
+            repolist = [x.name for x in repolist]
+            repos = uniq(repos + repolist)
+        except pass:
+            # TODO: Bad URL, report error?
+
     if ("repoList" in source):
         try:
             repolist = requests.get(source["repoList"]).json()


### PR DESCRIPTION
Takes a user/github-user-name or an orgs/github-org-name value,
and takes all the respositories there.