### PR TITLE
Get most recent commit id instead of relying on head_commit

### DIFF
--- a/index.py
+++ b/index.py
@@ -67,7 +67,7 @@ def event_id(event, payload):
     elif event.split(".")[0] == "issue_comment":
         return payload["comment"]["id"]
     elif event == "push":
-        return payload["head_commit"]["id"]
+        return payload["after"]
     elif event.split(".")[0] == "pull_request":
         return payload["pull_request"]["id"]
     elif event.split(".")[0] == "repository":


### PR DESCRIPTION
The server logs show that the payload for a `push` event may not have a `head_commit` property.
```
[cgi:error] [pid 3506356:tid 3506356] [client xxx] AH01215: stderr from github-notify-ml/index.py:   File "github-notify-ml/index.py", line 70, in event_id
[cgi:error] [pid 3506356:tid 3506356] [client xxx] AH01215: stderr from github-notify-ml/index.py:     return payload["head_commit"]["id"]
[cgi:error] [pid 3506356:tid 3506356] [client xxx] AH01215: stderr from github-notify-ml/index.py:            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^
[cgi:error] [pid 3506356:tid 3506356] [client xxx] AH01215: stderr from github-notify-ml/index.py: TypeError: 'NoneType' object is not subscriptable
```
Looking at the [documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads#push), it seems that property can indeed be null.

That PR updates the function to return the most recent commit id instead.